### PR TITLE
Fix a bug with missed verification

### DIFF
--- a/dbft.go
+++ b/dbft.go
@@ -66,7 +66,7 @@ func (d *DBFT) addTransaction(tx block.Transaction) {
 			return
 		}
 
-		if b := d.Context.MakeHeader(); !d.VerifyBlock(b) {
+		if b := d.Context.CreateBlock(); !d.VerifyBlock(b) {
 			d.Logger.Warn("can't verify transaction", zap.Stringer("hash", tx.Hash()))
 			d.sendChangeView()
 

--- a/dbft.go
+++ b/dbft.go
@@ -312,6 +312,11 @@ func (d *DBFT) onPrepareRequest(msg payload.ConsensusPayload) {
 
 	if !d.hasAllTransactions() {
 		return
+	} else if b := d.Context.CreateBlock(); !d.VerifyBlock(b) {
+		d.Logger.Warn("can't verify received block")
+		d.sendChangeView()
+
+		return
 	}
 
 	d.sendPrepareResponse()


### PR DESCRIPTION
In case when all transaction were already in pool by the time `PrepareRequest` was received, perform verification immediately.
Also add tests.