### PR TITLE
Invoke GetKeyPair after every block

### DIFF
--- a/context.go
+++ b/context.go
@@ -16,6 +16,11 @@ type Context struct {
 	// Config is dBFT's Config instance.
 	Config *Config
 
+	// Priv is node's private key.
+	Priv crypto.PrivateKey
+	// Pub is node's public key.
+	Pub crypto.PublicKey
+
 	block  block.Block
 	header block.Block
 
@@ -187,22 +192,7 @@ func (c *Context) reset(view byte) {
 		}
 	}
 
-	data, err := c.Config.Pub.MarshalBinary()
-	if err != nil {
-		panic("can't marshal config public key")
-	}
-
-	id := fetchID(data)
-
-	for i := range c.Validators {
-		data, err := c.Validators[i].MarshalBinary()
-		if err != nil {
-			panic("can't marshal public key")
-		} else if id == fetchID(data) {
-			c.MyIndex = i
-			break
-		}
-	}
+	c.MyIndex, c.Priv, c.Pub = c.Config.GetKeyPair(c.Validators)
 
 	c.header = nil
 

--- a/send.go
+++ b/send.go
@@ -104,7 +104,7 @@ func (c *Context) makeCommit() payload.ConsensusPayload {
 
 	if b := c.MakeHeader(); b != nil {
 		var sign []byte
-		if err := b.Sign(c.Config.Priv); err == nil {
+		if err := b.Sign(c.Priv); err == nil {
 			sign = b.Signature()
 		}
 


### PR DESCRIPTION
Sometimes a node can have more than one key pair.
In this case even if the set of validators has been changed,
node can still have another public key which can be used.

It will make it easier to implement behavior similar to C# node.
https://github.com/neo-project/neo/blob/master/src/neo/Consensus/ConsensusContext.cs#L380