### PR TITLE
context: wipe block and commits on ChangeView

### DIFF
--- a/context.go
+++ b/context.go
@@ -182,6 +182,8 @@ func (c *Context) reset(view byte) {
 			}
 		}
 	} else {
+		c.block = nil
+		c.CommitPayloads = make([]payload.ConsensusPayload, len(c.Validators))
 		for i := range c.Validators {
 			m := c.ChangeViewPayloads[i]
 			if m != nil && m.GetChangeView().NewViewNumber() < view {


### PR DESCRIPTION
If there is block from the previous view, it's no longer valid and won't be
ever accepted, so nuke it and also reset commits. Fixes #18.