### PR TITLE
dbft: don't extend timer when commit is from a different view

### DIFF
--- a/dbft.go
+++ b/dbft.go
@@ -441,9 +441,8 @@ func (d *DBFT) onChangeView(msg payload.ConsensusPayload) {
 }
 
 func (d *DBFT) onCommit(msg payload.ConsensusPayload) {
-	d.extendTimer(4)
-
 	if d.ViewNumber == msg.ViewNumber() {
+		d.extendTimer(4)
 		header := d.MakeHeader()
 		if header == nil {
 			d.CommitPayloads[msg.ValidatorIndex()] = msg


### PR DESCRIPTION
It can lead to the node being late to trigger a ChangeView when it's the
chosen one to process RecoveryRequest. Fixes #16.