### PR TITLE
log more at info level, follow (some of) neo-cli behavior

### DIFF
--- a/check.go
+++ b/check.go
@@ -61,7 +61,7 @@ func (d *DBFT) checkCommit() {
 	d.block = d.CreateBlock()
 	hash := d.block.Hash()
 
-	d.Logger.Debug("approving block",
+	d.Logger.Info("approving block",
 		zap.Uint32("height", d.BlockIndex),
 		zap.Stringer("hash", hash),
 		zap.Int("tx_count", len(d.block.Transactions())),

--- a/send.go
+++ b/send.go
@@ -37,6 +37,7 @@ func (d *DBFT) sendPrepareRequest() {
 		delay -= d.SecondsPerBlock
 	}
 
+	d.Logger.Info("sending PrepareRequest", zap.Uint32("height", d.BlockIndex), zap.Uint("view", uint(d.ViewNumber)))
 	d.changeTimer(delay)
 	d.checkPrepare()
 }
@@ -94,6 +95,7 @@ func (c *Context) makePrepareResponse() payload.ConsensusPayload {
 
 func (d *DBFT) sendPrepareResponse() {
 	msg := d.makePrepareResponse()
+	d.Logger.Info("sending PrepareResponse", zap.Uint32("height", d.BlockIndex), zap.Uint("view", uint(d.ViewNumber)))
 	d.broadcast(msg)
 }
 
@@ -120,6 +122,7 @@ func (c *Context) makeCommit() payload.ConsensusPayload {
 func (d *DBFT) sendCommit() {
 	msg := d.makeCommit()
 	d.CommitPayloads[d.MyIndex] = msg
+	d.Logger.Info("sending Commit", zap.Uint32("height", d.BlockIndex), zap.Uint("view", uint(d.ViewNumber)))
 	d.broadcast(msg)
 }
 


### PR DESCRIPTION
It's not exactly the same after this change, but it's a little closer and
allows to track consensus node state without debug enabled.