### PR TITLE
dbft: don't extend timer on commit msg rcvd if no proposal seen

### DIFF
--- a/dbft.go
+++ b/dbft.go
@@ -453,7 +453,9 @@ func (d *DBFT) onChangeView(msg payload.ConsensusPayload) {
 func (d *DBFT) onCommit(msg payload.ConsensusPayload) {
 	if d.ViewNumber == msg.ViewNumber() {
 		d.Logger.Info("received Commit", zap.Uint("validator", uint(msg.ValidatorIndex())))
-		d.extendTimer(4)
+		if d.RequestSentOrReceived() {
+			d.extendTimer(4)
+		}
 		header := d.MakeHeader()
 		if header == nil {
 			d.CommitPayloads[msg.ValidatorIndex()] = msg


### PR DESCRIPTION
Testnet:
Feb 13 21:12:35 nodoka neo-go[28475]: 2020-02-13T21:12:35.820+0300        INFO        initializing dbft        {"height": 3835345, "view": 0, "index": 6, "role": "Backup"}
...
Feb 13 21:12:43 nodoka neo-go[28475]: 2020-02-13T21:12:43.326+0300        INFO        received Commit        {"validator": 5}
Feb 13 21:12:43 nodoka neo-go[28475]: 2020-02-13T21:12:43.334+0300        INFO        received Commit        {"validator": 0}
Feb 13 21:12:43 nodoka neo-go[28475]: 2020-02-13T21:12:43.742+0300        INFO        received Commit        {"validator": 4}

That obviously delays consensus for another 16 minutes while it shouldn't.