### PR TITLE
Fix timer.Extend()

### DIFF
--- a/context.go
+++ b/context.go
@@ -223,7 +223,12 @@ func (c *Context) Fill() {
 
 	validators := c.Config.GetValidators(txx...)
 	c.NextConsensus = c.Config.GetConsensusAddress(validators...)
-	c.Timestamp = uint32(c.Config.Timer.Now().Unix())
+
+	if now := uint32(c.Config.Timer.Now().Unix()); now > c.Timestamp {
+		c.Timestamp = now
+	} else {
+		c.Timestamp++
+	}
 }
 
 // CreateBlock returns resulting block for the current epoch.

--- a/dbft.go
+++ b/dbft.go
@@ -555,6 +555,6 @@ func (d *DBFT) changeTimer(delay time.Duration) {
 
 func (d *DBFT) extendTimer(count time.Duration) {
 	if !d.CommitSent() && !d.ViewChanging() {
-		d.Timer.Extend(count * d.SecondsPerBlock / time.Second / time.Duration(len(d.Validators)-d.F()))
+		d.Timer.Extend(count * d.SecondsPerBlock / time.Duration(d.M()))
 	}
 }

--- a/timer/timer.go
+++ b/timer/timer.go
@@ -114,7 +114,7 @@ func (t *timer) loop() {
 					toSend.s = v.s
 					toSend.d = v.d
 				} else {
-					toSend.d *= v.d
+					toSend.d += v.d
 				}
 
 				stopTimer(tt)

--- a/timer/timer_test.go
+++ b/timer/timer_test.go
@@ -27,7 +27,7 @@ func TestTimer_Reset(t *testing.T) {
 	tt.Reset(HV{Height: 3, View: 1}, time.Millisecond*100)
 	shouldNotReceive(t, tt, "value arrived too early")
 
-	tt.Extend(4)
+	tt.Extend(time.Millisecond * 300)
 	tt.Sleep(time.Millisecond * 200)
 	shouldNotReceive(t, tt, "value arrived too early after extend")
 


### PR DESCRIPTION
It should Extend() by additive amount of time.
All multiplication is performed in extendTimer in dbft.go .

https://github.com/neo-project/neo/blob/master/src/neo/Consensus/ConsensusService.cs#L248