### PR TITLE
Improve stale node behavior

### DIFF
--- a/context.go
+++ b/context.go
@@ -105,10 +105,10 @@ func (c *Context) CountCommitted() (count int) {
 }
 
 // CountFailed returns number of nodes with which no communication was performed
-// for more than 1 epoch
+// for this block/view.
 func (c *Context) CountFailed() (count int) {
 	for _, hv := range c.LastSeenMessage {
-		if hv == nil || hv.Height != c.BlockIndex || hv.View != c.ViewNumber {
+		if hv == nil || hv.Height < c.BlockIndex || hv.View < c.ViewNumber {
 			count++
 		}
 	}

--- a/dbft.go
+++ b/dbft.go
@@ -215,7 +215,8 @@ func (d *DBFT) OnReceive(msg payload.ConsensusPayload) {
 	if msg.Height() < d.BlockIndex {
 		d.Logger.Debug("ignoring old height", zap.Uint32("height", msg.Height()))
 		return
-	} else if msg.Height() > d.BlockIndex || msg.Height() == d.BlockIndex && msg.ViewNumber() == d.ViewNumber+1 {
+	} else if msg.Height() > d.BlockIndex || (msg.Height() == d.BlockIndex &&
+		msg.ViewNumber() == d.ViewNumber+1 && msg.Type() != payload.RecoveryMessageType) {
 		d.Logger.Debug("caching message from future",
 			zap.Uint32("height", msg.Height()),
 			zap.Uint("view", uint(msg.ViewNumber())),


### PR DESCRIPTION
These patches are intended to improve behavior of an outdated (after reset) node that should be able to catch up with other ones eventually, but fails to do so at the moment.