### PR TITLE
dbft: fix timeout calculation in `InitializeConsensus`

### DIFF
--- a/check.go
+++ b/check.go
@@ -70,8 +70,6 @@ func (d *DBFT) checkCommit() {
 
 	d.ProcessBlock(d.block)
 
-	d.blockPersistTime = d.Timer.Now()
-
 	d.InitializeConsensus(0)
 
 	if d.MyIndex < 0 {

--- a/dbft.go
+++ b/dbft.go
@@ -19,9 +19,8 @@ type (
 		Config
 
 		*sync.Mutex
-		blockPersistTime time.Time
-		cache            cache
-		recovering       bool
+		cache      cache
+		recovering bool
 	}
 
 	// Service is an interface for dBFT consensus.
@@ -115,24 +114,18 @@ func (d *DBFT) InitializeConsensus(view byte) {
 		return
 	}
 
+	var timeout time.Duration
 	if d.IsPrimary() && !d.recovering {
-		var (
-			span time.Duration
-			def  time.Time
-		)
-
-		if d.blockPersistTime != def {
-			span = d.Timer.Now().Sub(d.blockPersistTime)
-		}
-
-		if span >= d.SecondsPerBlock {
-			d.changeTimer(0)
-		} else {
-			d.changeTimer(d.SecondsPerBlock - span)
+		// Initializing to view 0 means we have just persisted previous block or are starting consensus first time.
+		// In both cases we should wait full timeout value.
+		// Having non-zero view means we have to start immediately.
+		if view == 0 {
+			timeout = d.SecondsPerBlock
 		}
 	} else {
-		d.changeTimer(d.SecondsPerBlock << (d.ViewNumber + 1))
+		timeout = d.SecondsPerBlock << (d.ViewNumber + 1)
 	}
+	d.changeTimer(timeout)
 }
 
 // OnTransaction notifies service about receiving new transaction.


### PR DESCRIPTION
Closes #34 .

Remove `blockPersistTime` field and calculate timeout value
based on current view only. Time passed between block persist and
calling `InitializeConsensus` is of the order of milliseconds and is
assumed to be negligible.
This is needed because blocks can be acquired via network.
In this case persisting is done outside of dbft library.