### PR TITLE
*: remove TxPerBlock method

### DIFF
--- a/context.go
+++ b/context.go
@@ -211,7 +211,7 @@ func (c *Context) reset(view byte) {
 
 // Fill initializes consensus when node is a speaker.
 func (c *Context) Fill() {
-	txx := c.Config.GetVerified(c.Config.TxPerBlock)
+	txx := c.Config.GetVerified()
 	c.Nonce = rand.Uint64()
 	c.TransactionHashes = make([]util.Uint256, len(txx))
 

--- a/dbft_test.go
+++ b/dbft_test.go
@@ -567,12 +567,11 @@ func (s *testState) getOptions() []Option {
 		WithWatchOnly(func() bool { return false }),
 		WithGetBlock(func(h util.Uint256) block.Block { return nil }),
 		WithTimer(timer.New()),
-		WithTxPerBlock(5),
 		WithLogger(zap.NewNop()),
 		WithNewBlockFromContext(NewBlockFromContext),
 		WithSecondsPerBlock(time.Second * 10),
 		WithRequestTx(func(...util.Uint256) {}),
-		WithGetVerified(func(_ int) []block.Transaction { return []block.Transaction{} }),
+		WithGetVerified(func() []block.Transaction { return []block.Transaction{} }),
 
 		WithNewConsensusPayload(payload.NewConsensusPayload),
 		WithNewPrepareRequest(payload.NewPrepareRequest),

--- a/simulation/main.go
+++ b/simulation/main.go
@@ -125,7 +125,6 @@ func initSimNode(nodes []*simNode, i int, log *zap.Logger) error {
 
 	nodes[i].d = dbft.New(
 		dbft.WithLogger(nodes[i].log),
-		dbft.WithTxPerBlock(*txPerBlock),
 		dbft.WithSecondsPerBlock(time.Second*5),
 		dbft.WithKeyPair(key, pub),
 		dbft.WithGetTx(nodes[i].pool.Get),
@@ -285,7 +284,8 @@ func (p *memPool) Delete(h util.Uint256) {
 	p.mtx.Unlock()
 }
 
-func (p *memPool) GetVerified(n int) (txx []block.Transaction) {
+func (p *memPool) GetVerified() (txx []block.Transaction) {
+	n := *txPerBlock
 	if n == 0 {
 		return
 	}


### PR DESCRIPTION
After adding native Policy contract, GetVerifyed has it's own policy, so
we don't use TxPerBlock anywhere.