### PR TITLE
Remove marshaling methods from the ConsensusPayload interface

### DIFF
--- a/payload/constructors.go
+++ b/payload/constructors.go
@@ -2,7 +2,7 @@ package payload
 
 // NewConsensusPayload returns minimal ConsensusPayload implementation.
 func NewConsensusPayload() ConsensusPayload {
-	return &consensusPayload{}
+	return &Payload{}
 }
 
 // NewPrepareRequest returns minimal prepareRequest implementation.

--- a/payload/message.go
+++ b/payload/message.go
@@ -12,14 +12,6 @@ type (
 	ConsensusPayload interface {
 		consensusMessage
 
-		// MarshalUnsigned marshals payload into a byte array.
-		// It MUST be stable and contain no signatures and other
-		// fields which can be changed.
-		MarshalUnsigned() []byte
-
-		// UnmarshalUnsigned unmarshals payload from a byte array.
-		UnmarshalUnsigned([]byte) error
-
 		Version() uint32
 		SetVersion(v uint32)
 

--- a/payload/message.go
+++ b/payload/message.go
@@ -40,7 +40,8 @@ type (
 		Hash() util.Uint256
 	}
 
-	consensusPayload struct {
+	// Payload represents minimal payload containing all necessary fields.
+	Payload struct {
 		message
 
 		version        uint32
@@ -52,10 +53,10 @@ type (
 	}
 )
 
-var _ ConsensusPayload = (*consensusPayload)(nil)
+var _ ConsensusPayload = (*Payload)(nil)
 
 // EncodeBinary implements io.Serializable interface.
-func (p consensusPayload) EncodeBinary(w *io.BinWriter) {
+func (p Payload) EncodeBinary(w *io.BinWriter) {
 	ww := io.NewBufBinWriter()
 	p.message.EncodeBinary(ww.BinWriter)
 	data := ww.Bytes()
@@ -68,7 +69,7 @@ func (p consensusPayload) EncodeBinary(w *io.BinWriter) {
 }
 
 // DecodeBinary implements io.Serializable interface.
-func (p *consensusPayload) DecodeBinary(r *io.BinReader) {
+func (p *Payload) DecodeBinary(r *io.BinReader) {
 	p.version = r.ReadU32LE()
 	p.prevHash.DecodeBinary(r)
 	p.height = r.ReadU32LE()
@@ -80,7 +81,7 @@ func (p *consensusPayload) DecodeBinary(r *io.BinReader) {
 }
 
 // MarshalUnsigned implements ConsensusPayload interface.
-func (p consensusPayload) MarshalUnsigned() []byte {
+func (p Payload) MarshalUnsigned() []byte {
 	w := io.NewBufBinWriter()
 	p.EncodeBinary(w.BinWriter)
 
@@ -88,7 +89,7 @@ func (p consensusPayload) MarshalUnsigned() []byte {
 }
 
 // UnmarshalUnsigned implements ConsensusPayload interface.
-func (p *consensusPayload) UnmarshalUnsigned(data []byte) error {
+func (p *Payload) UnmarshalUnsigned(data []byte) error {
 	r := io.NewBinReaderFromBuf(data)
 	p.DecodeBinary(r)
 
@@ -96,7 +97,7 @@ func (p *consensusPayload) UnmarshalUnsigned(data []byte) error {
 }
 
 // Hash implements ConsensusPayload interface.
-func (p *consensusPayload) Hash() util.Uint256 {
+func (p *Payload) Hash() util.Uint256 {
 	if p.hash != nil {
 		return *p.hash
 	}
@@ -107,41 +108,41 @@ func (p *consensusPayload) Hash() util.Uint256 {
 }
 
 // Version implements ConsensusPayload interface.
-func (p consensusPayload) Version() uint32 {
+func (p Payload) Version() uint32 {
 	return p.version
 }
 
 // SetVersion implements ConsensusPayload interface.
-func (p *consensusPayload) SetVersion(v uint32) {
+func (p *Payload) SetVersion(v uint32) {
 	p.version = v
 }
 
 // ValidatorIndex implements ConsensusPayload interface.
-func (p consensusPayload) ValidatorIndex() uint16 {
+func (p Payload) ValidatorIndex() uint16 {
 	return p.validatorIndex
 }
 
 // SetValidatorIndex implements ConsensusPayload interface.
-func (p *consensusPayload) SetValidatorIndex(i uint16) {
+func (p *Payload) SetValidatorIndex(i uint16) {
 	p.validatorIndex = i
 }
 
 // PrevHash implements ConsensusPayload interface.
-func (p consensusPayload) PrevHash() util.Uint256 {
+func (p Payload) PrevHash() util.Uint256 {
 	return p.prevHash
 }
 
 // SetPrevHash implements ConsensusPayload interface.
-func (p *consensusPayload) SetPrevHash(h util.Uint256) {
+func (p *Payload) SetPrevHash(h util.Uint256) {
 	p.prevHash = h
 }
 
 // Height implements ConsensusPayload interface.
-func (p consensusPayload) Height() uint32 {
+func (p Payload) Height() uint32 {
 	return p.height
 }
 
 // SetHeight implements ConsensusPayload interface.
-func (p *consensusPayload) SetHeight(h uint32) {
+func (p *Payload) SetHeight(h uint32) {
 	p.height = h
 }

--- a/payload/message_test.go
+++ b/payload/message_test.go
@@ -214,7 +214,7 @@ func testEncodeDecode(t *testing.T, expected, actual io.Serializable) {
 	require.Equal(t, expected, actual)
 }
 
-func testMarshalUnmarshal(t *testing.T, expected, actual ConsensusPayload) {
+func testMarshalUnmarshal(t *testing.T, expected, actual *Payload) {
 	data := expected.MarshalUnsigned()
 	require.NoError(t, actual.UnmarshalUnsigned(data))
 	require.Equal(t, expected.Hash(), actual.Hash())

--- a/payload/message_test.go
+++ b/payload/message_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPayload_EncodeDecode(t *testing.T) {
-	m := NewConsensusPayload().(*consensusPayload)
+	m := NewConsensusPayload().(*Payload)
 	m.SetValidatorIndex(10)
 	m.SetHeight(77)
 	m.SetPrevHash(util.Uint256{1})
@@ -30,8 +30,8 @@ func TestPayload_EncodeDecode(t *testing.T) {
 			},
 		})
 
-		testEncodeDecode(t, m, new(consensusPayload))
-		testMarshalUnmarshal(t, m, new(consensusPayload))
+		testEncodeDecode(t, m, new(Payload))
+		testMarshalUnmarshal(t, m, new(Payload))
 	})
 
 	t.Run("PrepareResponse", func(t *testing.T) {
@@ -40,8 +40,8 @@ func TestPayload_EncodeDecode(t *testing.T) {
 			preparationHash: util.Uint256{3},
 		})
 
-		testEncodeDecode(t, m, new(consensusPayload))
-		testMarshalUnmarshal(t, m, new(consensusPayload))
+		testEncodeDecode(t, m, new(Payload))
+		testMarshalUnmarshal(t, m, new(Payload))
 	})
 
 	t.Run("Commit", func(t *testing.T) {
@@ -50,8 +50,8 @@ func TestPayload_EncodeDecode(t *testing.T) {
 		fillRandom(t, cc.signature[:])
 		m.SetPayload(&cc)
 
-		testEncodeDecode(t, m, new(consensusPayload))
-		testMarshalUnmarshal(t, m, new(consensusPayload))
+		testEncodeDecode(t, m, new(Payload))
+		testMarshalUnmarshal(t, m, new(Payload))
 	})
 
 	t.Run("ChangeView", func(t *testing.T) {
@@ -61,8 +61,8 @@ func TestPayload_EncodeDecode(t *testing.T) {
 			newViewNumber: 4,
 		})
 
-		testEncodeDecode(t, m, new(consensusPayload))
-		testMarshalUnmarshal(t, m, new(consensusPayload))
+		testEncodeDecode(t, m, new(Payload))
+		testMarshalUnmarshal(t, m, new(Payload))
 	})
 
 	t.Run("RecoveryMessage", func(t *testing.T) {
@@ -91,8 +91,8 @@ func TestPayload_EncodeDecode(t *testing.T) {
 			},
 		})
 
-		testEncodeDecode(t, m, new(consensusPayload))
-		testMarshalUnmarshal(t, m, new(consensusPayload))
+		testEncodeDecode(t, m, new(Payload))
+		testMarshalUnmarshal(t, m, new(Payload))
 	})
 
 	t.Run("RecoveryRequest", func(t *testing.T) {
@@ -101,13 +101,13 @@ func TestPayload_EncodeDecode(t *testing.T) {
 			timestamp: 17334,
 		})
 
-		testEncodeDecode(t, m, new(consensusPayload))
-		testMarshalUnmarshal(t, m, new(consensusPayload))
+		testEncodeDecode(t, m, new(Payload))
+		testMarshalUnmarshal(t, m, new(Payload))
 	})
 }
 
 func TestRecoveryMessage_NoPayloads(t *testing.T) {
-	m := NewConsensusPayload().(*consensusPayload)
+	m := NewConsensusPayload().(*Payload)
 	m.SetValidatorIndex(0)
 	m.SetHeight(77)
 	m.SetPrevHash(util.Uint256{1})

--- a/payload/recovery_message.go
+++ b/payload/recovery_message.go
@@ -77,8 +77,8 @@ func (m *recoveryMessage) AddPayload(p ConsensusPayload) {
 	}
 }
 
-func fromPayload(t MessageType, recovery ConsensusPayload, p interface{}) *consensusPayload {
-	return &consensusPayload{
+func fromPayload(t MessageType, recovery ConsensusPayload, p interface{}) *Payload {
+	return &Payload{
 		message: message{
 			cmType:     t,
 			viewNumber: recovery.ViewNumber(),


### PR DESCRIPTION
They were intended to be used for signing and verification which is now not a part of this library.