### PR TITLE
timer: remove goroutine from the timer

### DIFF
--- a/simulation/main.go
+++ b/simulation/main.go
@@ -96,8 +96,8 @@ func (n *simNode) Run(ctx context.Context) {
 		case <-ctx.Done():
 			n.log.Info("context cancelled")
 			return
-		case hv := <-n.d.Timer.C():
-			n.d.OnTimeout(hv)
+		case <-n.d.Timer.C():
+			n.d.OnTimeout(n.d.Timer.HV())
 		case msg := <-n.messages:
 			n.d.OnReceive(msg)
 		}

--- a/timer/timer_test.go
+++ b/timer/timer_test.go
@@ -42,7 +42,8 @@ func TestTimer_Reset(t *testing.T) {
 
 func shouldReceive(t *testing.T, tt Timer, hv HV, msg string) {
 	select {
-	case got := <-tt.C():
+	case <-tt.C():
+		got := tt.HV()
 		require.Equal(t, hv, got)
 	default:
 		require.Fail(t, msg)


### PR DESCRIPTION
There is no need for it, dbft is single-threaded. All users need to be updated
like this and that's it:

-               case hv := <-s.dbft.Timer.C():
+               case <-s.dbft.Timer.C():
+                       hv := s.dbft.Timer.HV()