### PR TITLE
dbft: adjust timer setting by the block processing time

### DIFF
--- a/check.go
+++ b/check.go
@@ -58,6 +58,8 @@ func (d *DBFT) checkCommit() {
 		return
 	}
 
+	d.lastBlockIndex = d.BlockIndex
+	d.lastBlockTime = d.Timer.Now()
 	d.block = d.CreateBlock()
 	hash := d.block.Hash()
 

--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package dbft
 
 import (
 	"math/rand"
+	"time"
 
 	"github.com/nspcc-dev/dbft/block"
 	"github.com/nspcc-dev/dbft/crypto"
@@ -63,6 +64,9 @@ type Context struct {
 	// LastSeenMessage array stores the height of the last seen message, for each validator.
 	// if this node never heard from validator i, LastSeenMessage[i] will be -1.
 	LastSeenMessage []*timer.HV
+
+	lastBlockTime  time.Time
+	lastBlockIndex uint32
 }
 
 // N returns total number of validators.

--- a/dbft.go
+++ b/dbft.go
@@ -123,6 +123,14 @@ func (d *DBFT) InitializeConsensus(view byte) {
 	} else {
 		timeout = d.SecondsPerBlock << (d.ViewNumber + 1)
 	}
+	if d.lastBlockIndex+1 == d.BlockIndex {
+		var ts = d.Timer.Now()
+		var diff = ts.Sub(d.lastBlockTime)
+		timeout -= diff
+		if timeout < 0 {
+			timeout = 0
+		}
+	}
 	d.changeTimer(timeout)
 }
 


### PR DESCRIPTION
Make block timing more accurate under load. BlockIndex is needed to
distinguish between consensus-produced block and the one added via regular
block addition mechanism.

See neo-project/neo#1959 and neo-project/neo#1960.