### PR TITLE
dbft: use `TimestampIncrement` as granularity

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,19 +11,19 @@ jobs:
     steps:
 
     - name: Setup go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Set GOPATH
       # temporary fix
       # see https://github.com/actions/setup-go/issues/14
       run: |
-        echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
-        echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
+        echo "GOPATH=$(dirname $GITHUB_WORKSPACE)" >> $GITHUB_ENV
+        echo "$(dirname $GITHUB_WORKSPACE)/bin" >> $GITHUB_PATH
       shell: bash
 
     - name: Get dependencies

--- a/context.go
+++ b/context.go
@@ -241,7 +241,7 @@ func (c *Context) Fill() {
 // getTimestamp returns nanoseconds-precision timestamp using
 // current context config.
 func (c *Context) getTimestamp() uint64 {
-	return uint64(c.Config.Timer.Now().UnixNano())
+	return uint64(c.Config.Timer.Now().UnixNano()) / c.Config.TimestampIncrement * c.Config.TimestampIncrement
 }
 
 // CreateBlock returns resulting block for the current epoch.


### PR DESCRIPTION
If timestamp is cut (from ns to ms), local context can have timestamp
which differs from other context. This can lead to a situation when
|request timestamp - context timestamp| is less than
`TimestampIncrement`, but which is valid from the POV of other nodes.