### PR TITLE
dbft: fix possible panic in `OnTransaction()`

### DIFF
--- a/dbft.go
+++ b/dbft.go
@@ -151,6 +151,11 @@ func (d *DBFT) OnTransaction(tx block.Transaction) {
 	for i := range d.MissingTransactions {
 		if tx.Hash() == d.MissingTransactions[i] {
 			d.addTransaction(tx)
+			// `addTransaction` checks for responses and commits. If this was the last transaction
+			// Context could be initialized on a new height, clearing this field.
+			if len(d.MissingTransactions) == 0 {
+				return
+			}
 			theLastOne := len(d.MissingTransactions) - 1
 			if i < theLastOne {
 				d.MissingTransactions[i] = d.MissingTransactions[theLastOne]


### PR DESCRIPTION
When transaction added is the only missing tx and we have all messages
to go to the next height this will be done and `MissingTransactions`
field will be cleared.