### PR TITLE
Move `Version` and `PrevHash` to `PrepareRequest`

### DIFF
--- a/config.go
+++ b/config.go
@@ -61,7 +61,7 @@ type Config struct {
 	// GetConsensusAddress returns hash of the validator list.
 	GetConsensusAddress func(...crypto.PublicKey) util.Uint160
 	// NewConsensusPayload is a constructor for payload.ConsensusPayload.
-	NewConsensusPayload func() payload.ConsensusPayload
+	NewConsensusPayload func(*Context, payload.MessageType, interface{}) payload.ConsensusPayload
 	// NewPrepareRequest is a constructor for payload.PrepareRequest.
 	NewPrepareRequest func() payload.PrepareRequest
 	// NewPrepareResponse is a constructor for payload.PrepareResponse.
@@ -108,7 +108,7 @@ func defaultConfig() *Config {
 		CurrentBlockHash:    nil,
 		GetValidators:       nil,
 		GetConsensusAddress: func(...crypto.PublicKey) util.Uint160 { return util.Uint160{} },
-		NewConsensusPayload: payload.NewConsensusPayload,
+		NewConsensusPayload: defaultNewConsensusPayload,
 		NewPrepareRequest:   payload.NewPrepareRequest,
 		NewPrepareResponse:  payload.NewPrepareResponse,
 		NewChangeView:       payload.NewChangeView,
@@ -286,7 +286,7 @@ func WithGetConsensusAddress(f func(keys ...crypto.PublicKey) util.Uint160) Opti
 }
 
 // WithNewConsensusPayload sets NewConsensusPayload.
-func WithNewConsensusPayload(f func() payload.ConsensusPayload) Option {
+func WithNewConsensusPayload(f func(*Context, payload.MessageType, interface{}) payload.ConsensusPayload) Option {
 	return func(cfg *Config) {
 		cfg.NewConsensusPayload = f
 	}

--- a/dbft_test.go
+++ b/dbft_test.go
@@ -581,7 +581,7 @@ func (s *testState) getOptions() []Option {
 		WithRequestTx(func(...util.Uint256) {}),
 		WithGetVerified(func() []block.Transaction { return []block.Transaction{} }),
 
-		WithNewConsensusPayload(payload.NewConsensusPayload),
+		WithNewConsensusPayload(defaultNewConsensusPayload),
 		WithNewPrepareRequest(payload.NewPrepareRequest),
 		WithNewPrepareResponse(payload.NewPrepareResponse),
 		WithNewChangeView(payload.NewChangeView),

--- a/payload/message.go
+++ b/payload/message.go
@@ -12,18 +12,12 @@ type (
 	ConsensusPayload interface {
 		consensusMessage
 
-		Version() uint32
-		SetVersion(v uint32)
-
 		// ValidatorIndex returns index of validator from which
 		// payload was originated from.
 		ValidatorIndex() uint16
 
 		// SetValidator index sets validator index.
 		SetValidatorIndex(i uint16)
-
-		PrevHash() util.Uint256
-		SetPrevHash(h util.Uint256)
 
 		Height() uint32
 		SetHeight(h uint32)

--- a/payload/recovery_message.go
+++ b/payload/recovery_message.go
@@ -84,9 +84,7 @@ func fromPayload(t MessageType, recovery ConsensusPayload, p interface{}) *Paylo
 			viewNumber: recovery.ViewNumber(),
 			payload:    p,
 		},
-		version:  recovery.Version(),
-		prevHash: recovery.PrevHash(),
-		height:   recovery.Height(),
+		height: recovery.Height(),
 	}
 }
 

--- a/send.go
+++ b/send.go
@@ -180,7 +180,6 @@ func (d *DBFT) sendRecoveryMessage() {
 
 func (c *Context) withPayload(t payload.MessageType, payload interface{}) payload.ConsensusPayload {
 	cp := c.Config.NewConsensusPayload()
-	cp.SetPrevHash(c.PrevHash)
 	cp.SetHeight(c.BlockIndex)
 	cp.SetValidatorIndex(uint16(c.MyIndex))
 	cp.SetViewNumber(c.ViewNumber)


### PR DESCRIPTION
Implement things needed for new extensible payloads for consensus in neo-go.