### PR TITLE
check: set lastBlockTime in PrepareRequest handler, fix #55

### DIFF
--- a/check.go
+++ b/check.go
@@ -6,6 +6,11 @@ import (
 )
 
 func (d *DBFT) checkPrepare() {
+	if d.lastBlockIndex != d.BlockIndex || d.lastBlockView != d.ViewNumber {
+		d.lastBlockTime = d.Timer.Now()
+		d.lastBlockIndex = d.BlockIndex
+		d.lastBlockView = d.ViewNumber
+	}
 	if !d.hasAllTransactions() {
 		d.Logger.Debug("check prepare: some transactions are missing", zap.Any("hashes", d.MissingTransactions))
 		return
@@ -58,8 +63,6 @@ func (d *DBFT) checkCommit() {
 		return
 	}
 
-	d.lastBlockIndex = d.BlockIndex
-	d.lastBlockTime = d.Timer.Now()
 	d.block = d.CreateBlock()
 	hash := d.block.Hash()
 

--- a/context.go
+++ b/context.go
@@ -68,6 +68,7 @@ type Context struct {
 
 	lastBlockTime  time.Time
 	lastBlockIndex uint32
+	lastBlockView  byte
 }
 
 // N returns total number of validators.


### PR DESCRIPTION
It's the earliest point, if a view change happens the timer is reset (because
new view comes with a new set of transactions, potentially picking up ones
received between views).