### PR TITLE
context: do not create header until PrepareRequest is received/sent

### DIFF
--- a/context.go
+++ b/context.go
@@ -274,6 +274,9 @@ func (c *Context) CreateBlock() block.Block {
 // All hashable fields will be filled.
 func (c *Context) MakeHeader() block.Block {
 	if c.header == nil {
+		if !c.RequestSentOrReceived() {
+			return nil
+		}
 		c.header = c.Config.NewBlockFromContext(c)
 	}
 


### PR DESCRIPTION
Consider the situation when ChangeView was received and Context's block
was reset. If we receive PrepareResponse or Commit on this stage, then
the old block will be recreated, because we haven't got new PrepareRequest
with the newly proposed block. All newly-received Commits will fail
verification then.