### PR TITLE
send: don't skip CV if anything is wrong with the proposal

### DIFF
--- a/send.go
+++ b/send.go
@@ -65,7 +65,7 @@ func (d *DBFT) sendChangeView(reason payload.ChangeViewReason) {
 	nc := d.CountCommitted()
 	nf := d.CountFailed()
 
-	if nc+nf > d.F() {
+	if reason == payload.CVTimeout && nc+nf > d.F() {
 		d.Logger.Info("skip change view", zap.Int("nc", nc), zap.Int("nf", nf))
 		d.sendRecoveryRequest()
 


### PR DESCRIPTION
ChangeView must not be skipped in case the proposal is wrong:

мая 23 08:24:14  neogo-n3c[14835]: 2022-05-23T08:24:14.040+0300        INFO        initializing dbft        {"height": 1584313, "view": 0, "index": 6, "role": "Backup"}
мая 23 08:24:14  neogo-n3c[14835]: 2022-05-23T08:24:14.764+0300        INFO        persisted to disk        {"blocks": 1, "keys": 78, "headerHeight": 1584312, "blockHeight": 1584312, "took": "4.16107ms"}
мая 23 08:24:29  neogo-n3c[14835]: 2022-05-23T08:24:29.227+0300        INFO        received PrepareResponse        {"validator": 4}
мая 23 08:24:29  neogo-n3c[14835]: 2022-05-23T08:24:29.228+0300        INFO        received PrepareRequest        {"validator": 3, "tx": 5}
мая 23 08:24:29  neogo-n3c[14835]: 2022-05-23T08:24:29.228+0300        INFO        missing tx        {"count": 1}
мая 23 08:24:29  neogo-n3c[14835]: 2022-05-23T08:24:29.265+0300        INFO        received PrepareResponse        {"validator": 2}
мая 23 08:24:29  neogo-n3c[14835]: 2022-05-23T08:24:29.281+0300        WARN        invalid transaction in proposed block        {"hash": "4ae365486197b3e7661b300d5df761bcbbeae39bfe1656b1f78b32210ff287db", "error": "insufficient funds"}
мая 23 08:24:29  neogo-n3c[14835]: 2022-05-23T08:24:29.282+0300        WARN        proposed block fails verification
мая 23 08:24:29  neogo-n3c[14835]: 2022-05-23T08:24:29.282+0300        INFO        skip change view        {"nc": 0, "nf": 3}