### PR TITLE
dbft: increase amount of nodes responding to RecoveryRequest

### DIFF
--- a/dbft.go
+++ b/dbft.go
@@ -515,7 +515,7 @@ func (d *DBFT) onRecoveryRequest(msg payload.ConsensusPayload) {
 		// TODO replace loop with a single if
 		shouldSend := false
 
-		for i := 1; i <= d.F(); i++ {
+		for i := 1; i <= d.F()+1; i++ {
 			ind := (int(msg.ValidatorIndex()) + i) % len(d.Validators)
 			if ind == d.MyIndex {
 				shouldSend = true


### PR DESCRIPTION
If F nodes are down, consensus should be able to function, so at least
F+1 nodes must be able to respond.

Refs. https://github.com/neo-project/neo-modules/issues/722

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>