### PR TITLE
config: add StopTxFlow callback

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,6 +34,9 @@ type Config struct {
 	// RequestTx is a callback which is called when transaction contained
 	// in current block can't be found in memory pool.
 	RequestTx func(h ...util.Uint256)
+	// StopTxFlow is a callback which is called when the process no longer needs
+	// any transactions.
+	StopTxFlow func()
 	// GetTx returns a transaction from memory pool.
 	GetTx func(h util.Uint256) block.Transaction
 	// GetVerified returns a slice of verified transactions
@@ -97,6 +100,7 @@ func defaultConfig() *Config {
 		GetKeyPair:          nil,
 		NewBlockFromContext: NewBlockFromContext,
 		RequestTx:           func(h ...util.Uint256) {},
+		StopTxFlow:          func() {},
 		GetTx:               func(h util.Uint256) block.Transaction { return nil },
 		GetVerified:         func() []block.Transaction { return make([]block.Transaction, 0) },
 		VerifyBlock:         func(b block.Block) bool { return true },
@@ -205,6 +209,13 @@ func WithNewBlockFromContext(f func(ctx *Context) block.Block) Option {
 func WithRequestTx(f func(h ...util.Uint256)) Option {
 	return func(cfg *Config) {
 		cfg.RequestTx = f
+	}
+}
+
+// WithStopTxFlow sets StopTxFlow.
+func WithStopTxFlow(f func()) Option {
+	return func(cfg *Config) {
+		cfg.StopTxFlow = f
 	}
 }
 

--- a/dbft.go
+++ b/dbft.go
@@ -102,6 +102,7 @@ func (d *DBFT) InitializeConsensus(view byte) {
 		logMsg = "changing dbft view"
 	}
 
+	d.StopTxFlow()
 	d.Logger.Info(logMsg,
 		zap.Uint32("height", d.BlockIndex),
 		zap.Uint("view", uint(view)),

--- a/send.go
+++ b/send.go
@@ -86,6 +86,7 @@ func (d *DBFT) sendChangeView(reason payload.ChangeViewReason) {
 		zap.Int("nf", nf))
 
 	msg := d.makeChangeView(uint64(d.Timer.Now().UnixNano()), reason)
+	d.StopTxFlow()
 	d.broadcast(msg)
 	d.checkChangeView(newView)
 }
@@ -103,6 +104,7 @@ func (c *Context) makePrepareResponse() payload.ConsensusPayload {
 func (d *DBFT) sendPrepareResponse() {
 	msg := d.makePrepareResponse()
 	d.Logger.Info("sending PrepareResponse", zap.Uint32("height", d.BlockIndex), zap.Uint("view", uint(d.ViewNumber)))
+	d.StopTxFlow()
 	d.broadcast(msg)
 }
 


### PR DESCRIPTION
Most of the time consensus process doesn't need any incoming transactions, only after RequestTx() call it does, but then it'd be nice to signal when it's done with transaction processing and that's what StopTxFlow() does.