### PR TITLE
*: replace `interface{}` with `any` keyword

### DIFF
--- a/payload/consensus_message.go
+++ b/payload/consensus_message.go
@@ -23,9 +23,9 @@ type (
 		SetType(t MessageType)
 
 		// Payload returns this message's actual payload.
-		Payload() interface{}
+		Payload() any
 		// SetPayload sets this message's payload to p.
-		SetPayload(p interface{})
+		SetPayload(p any)
 
 		// GetChangeView returns payload as if it was ChangeView.
 		GetChangeView() ChangeView
@@ -45,7 +45,7 @@ type (
 		cmType     MessageType
 		viewNumber byte
 
-		payload interface{}
+		payload any
 	}
 )
 
@@ -144,11 +144,11 @@ func (m *message) SetType(t MessageType) {
 }
 
 // Payload implements ConsensusMessage interface.
-func (m message) Payload() interface{} {
+func (m message) Payload() any {
 	return m.payload
 }
 
 // SetPayload implements ConsensusMessage interface.
-func (m *message) SetPayload(p interface{}) {
+func (m *message) SetPayload(p any) {
 	m.payload = p
 }

--- a/payload/recovery_message.go
+++ b/payload/recovery_message.go
@@ -77,7 +77,7 @@ func (m *recoveryMessage) AddPayload(p ConsensusPayload) {
 	}
 }
 
-func fromPayload(t MessageType, recovery ConsensusPayload, p interface{}) *Payload {
+func fromPayload(t MessageType, recovery ConsensusPayload, p any) *Payload {
 	return &Payload{
 		message: message{
 			cmType:     t,


### PR DESCRIPTION
Should be a part of https://github.com/nspcc-dev/dbft/pull/72, but turns out that Goland's "Find and replace" manager searches over vendor directory as far and does not include the whole set of search results if there are too many of them.