### PR TITLE
crypto: drop neofs-crypto dependency

### DIFF
--- a/crypto/ecdsa.go
+++ b/crypto/ecdsa.go
@@ -3,10 +3,12 @@ package crypto
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/sha256"
 	"errors"
 	"io"
+	"math/big"
 
-	crypto "github.com/nspcc-dev/neofs-crypto"
+	"github.com/nspcc-dev/rfc6979"
 )
 
 type (
@@ -45,25 +47,28 @@ func NewECDSAPrivateKey(key *ecdsa.PrivateKey) PrivateKey {
 }
 
 // Sign signs message using P-256 curve.
-func (e ECDSAPriv) Sign(msg []byte) (sig []byte, err error) {
-	sig, err = crypto.Sign(e.PrivateKey, msg)
-	if err != nil {
-		return nil, err
-	}
+func (e ECDSAPriv) Sign(msg []byte) ([]byte, error) {
+	h := sha256.Sum256(msg)
+	r, s := rfc6979.SignECDSA(e.PrivateKey, h[:], sha256.New)
 
-	// we chomp first 0x04 (uncompressed) byte
-	return sig[1:], err
+	sig := make([]byte, 32*2)
+	_ = r.FillBytes(sig[:32])
+	_ = s.FillBytes(sig[32:])
+
+	return sig, nil
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler interface.
 func (e ECDSAPub) MarshalBinary() ([]byte, error) {
-	return crypto.MarshalPublicKey(e.PublicKey), nil
+	return elliptic.MarshalCompressed(e.PublicKey.Curve, e.PublicKey.X, e.PublicKey.Y), nil
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler interface.
 func (e *ECDSAPub) UnmarshalBinary(data []byte) error {
-	e.PublicKey = crypto.UnmarshalPublicKey(data)
-	if e.PublicKey == nil {
+	e.PublicKey = new(ecdsa.PublicKey)
+	e.PublicKey.Curve = elliptic.P256()
+	e.PublicKey.X, e.PublicKey.Y = elliptic.UnmarshalCompressed(e.PublicKey.Curve, data)
+	if e.PublicKey.X == nil {
 		return errors.New("can't unmarshal ECDSA public key")
 	}
 
@@ -72,5 +77,12 @@ func (e *ECDSAPub) UnmarshalBinary(data []byte) error {
 
 // Verify verifies signature using P-256 curve.
 func (e ECDSAPub) Verify(msg, sig []byte) error {
-	return crypto.Verify(e.PublicKey, msg, append([]byte{0x04}, sig...))
+	h := sha256.Sum256(msg)
+	rBytes := new(big.Int).SetBytes(sig[0:32])
+	sBytes := new(big.Int).SetBytes(sig[32:64])
+	res := ecdsa.Verify(e.PublicKey, h[:], rBytes, sBytes)
+	if !res {
+		return errors.New("bad signature")
+	}
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/nspcc-dev/dbft
 go 1.19
 
 require (
-	github.com/nspcc-dev/neofs-crypto v0.4.0
+	github.com/nspcc-dev/rfc6979 v0.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.7.0
@@ -13,8 +13,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/mr-tron/base58 v1.2.0 // indirect
-	github.com/nspcc-dev/rfc6979 v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
-github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
-github.com/nspcc-dev/neofs-crypto v0.4.0 h1:5LlrUAM5O0k1+sH/sktBtrgfWtq1pgpDs09fZo+KYi4=
-github.com/nspcc-dev/neofs-crypto v0.4.0/go.mod h1:6XJ8kbXgOfevbI2WMruOtI+qUJXNwSGM/E9eClXxPHs=
 github.com/nspcc-dev/rfc6979 v0.2.0 h1:3e1WNxrN60/6N0DW7+UYisLeZJyfqZTNOjeV/toYvOE=
 github.com/nspcc-dev/rfc6979 v0.2.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=


### PR DESCRIPTION
It's just a test code in its essence, so it doesn't matter what it uses.