### PR TITLE
internal: drop rfc6979 dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/nspcc-dev/dbft
 go 1.20
 
 require (
-	github.com/nspcc-dev/rfc6979 v0.2.1
 	github.com/stretchr/testify v1.9.0
 	github.com/twmb/murmur3 v1.1.8
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/nspcc-dev/rfc6979 v0.2.1 h1:8wWxkamHWFmO790GsewSoKUSJjVnL1fmdRpokU/RgRM=
-github.com/nspcc-dev/rfc6979 v0.2.1/go.mod h1:Tk7h5kyUWkhjyO3zUgFFhy1v2vQv3BvQEntakdtqrWc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/internal/crypto/ecdsa.go
+++ b/internal/crypto/ecdsa.go
@@ -3,13 +3,13 @@ package crypto
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/sha256"
 	"errors"
 	"io"
 	"math/big"
 
 	"github.com/nspcc-dev/dbft"
-	"github.com/nspcc-dev/rfc6979"
 )
 
 type (
@@ -50,7 +50,10 @@ func NewECDSAPrivateKey(key *ecdsa.PrivateKey) dbft.PrivateKey {
 // Sign signs message using P-256 curve.
 func (e ECDSAPriv) Sign(msg []byte) ([]byte, error) {
 	h := sha256.Sum256(msg)
-	r, s := rfc6979.SignECDSA(e.PrivateKey, h[:], sha256.New)
+	r, s, err := ecdsa.Sign(rand.Reader, e.PrivateKey, h[:])
+	if err != nil {
+		return nil, err
+	}
 
 	sig := make([]byte, 32*2)
 	_ = r.FillBytes(sig[:32])


### PR DESCRIPTION
Nothing bad about it, but we can easily live without it as well, it's not a production code. Less things to care about here.