### PR TITLE
context: properly reset preBlock and preHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Improvements:
  * minimum required Go version is 1.22 (#122, #126)
 
 Bugs fixed:
+ * context-bound PreBlock and PreHeader are not reset properly (#127)   
 
 ## [0.3.0] (01 August 2024)
 

--- a/context.go
+++ b/context.go
@@ -247,7 +247,9 @@ func (c *Context[H]) reset(view byte, ts uint64) {
 	c.MyIndex, c.Priv, c.Pub = c.Config.GetKeyPair(c.Validators)
 
 	c.block = nil
+	c.preBlock = nil
 	c.header = nil
+	c.preHeader = nil
 
 	n := len(c.Validators)
 	c.ChangeViewPayloads = emptyReusableSlice(c.ChangeViewPayloads, n)


### PR DESCRIPTION
I just don't believe it's possible, I was sure that I've added this resetting code. Required for https://github.com/bane-labs/go-ethereum/pull/287.