### PR TITLE
send: construct PreBlock instead of PreHeader to create PreCommit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Improvements:
 
 Bugs fixed:
  * context-bound PreBlock and PreHeader are not reset properly (#127)   
+ * PreHeader is constructed instead of PreBlock to create PreCommit message (#128)
 
 ## [0.3.0] (01 August 2024)
 

--- a/send.go
+++ b/send.go
@@ -104,7 +104,7 @@ func (c *Context[H]) makePreCommit() ConsensusPayload[H] {
 		return msg
 	}
 
-	if preB := c.MakePreHeader(); preB != nil {
+	if preB := c.CreatePreBlock(); preB != nil {
 		var preData []byte
 		if err := preB.SetData(c.Priv); err == nil {
 			preData = preB.Data()


### PR DESCRIPTION
PreHeader is not enough to create PreCommit because PreCommit requires the whole set of transactions to be available for PreCommit data calculations. This bug leads to the fact that Primary node can't properly construct valid PreCommit message because block's transactions are not yet filled by dBFT by this moment.

Required by https://github.com/bane-labs/go-ethereum/pull/287.

Draft because I need to carefully ensure that nothing is broken by this change for non-primary nodes. I checked that `CreatePreBlock` is called only when all transactions are available (as expected).