### PR TITLE
*: extend PreBlock processing callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This document outlines major changes between releases.
 New features:
 
 Behaviour changes:
+ * adjust behaviour of ProcessPreBlock callback (#129)
 
 Improvements:
  * minimum required Go version is 1.22 (#122, #126)

--- a/check.go
+++ b/check.go
@@ -62,14 +62,21 @@ func (d *DBFT[H]) checkPreCommit() {
 
 	d.preBlock = d.CreatePreBlock()
 
-	d.Logger.Info("processing PreBlock",
-		zap.Uint32("height", d.BlockIndex),
-		zap.Uint("view", uint(d.ViewNumber)),
-		zap.Int("tx_count", len(d.preBlock.Transactions())))
-
 	if !d.preBlockProcessed {
+		d.Logger.Info("processing PreBlock",
+			zap.Uint32("height", d.BlockIndex),
+			zap.Uint("view", uint(d.ViewNumber)),
+			zap.Int("tx_count", len(d.preBlock.Transactions())),
+			zap.Int("preCommit_count", count))
+
+		err := d.ProcessPreBlock(d.preBlock)
+		if err != nil {
+			d.Logger.Info("can't process PreBlock, waiting for more PreCommits to be collected",
+				zap.Error(err),
+				zap.Int("count", count))
+			return
+		}
 		d.preBlockProcessed = true
-		d.ProcessPreBlock(d.preBlock)
 	}
 
 	// Require PreCommit sent by self for reliability. This condition may be removed

--- a/check.go
+++ b/check.go
@@ -56,7 +56,7 @@ func (d *DBFT[H]) checkPreCommit() {
 	}
 
 	if count < d.M() {
-		d.Logger.Debug("not enough PreCommits to create PreBlock", zap.Int("count", count))
+		d.Logger.Debug("not enough PreCommits to process PreBlock", zap.Int("count", count))
 		return
 	}
 

--- a/config.go
+++ b/config.go
@@ -49,7 +49,7 @@ type Config[H Hash] struct {
 	// Broadcast should broadcast payload m to the consensus nodes.
 	Broadcast func(m ConsensusPayload[H])
 	// ProcessBlock is called every time new preBlock is accepted.
-	ProcessPreBlock func(b PreBlock[H])
+	ProcessPreBlock func(b PreBlock[H]) error
 	// ProcessBlock is called every time new block is accepted.
 	ProcessBlock func(b Block[H])
 	// GetBlock should return block with hash.
@@ -283,7 +283,7 @@ func WithProcessBlock[H Hash](f func(b Block[H])) func(config *Config[H]) {
 }
 
 // WithProcessPreBlock sets ProcessPreBlock.
-func WithProcessPreBlock[H Hash](f func(b PreBlock[H])) func(config *Config[H]) {
+func WithProcessPreBlock[H Hash](f func(b PreBlock[H]) error) func(config *Config[H]) {
 	return func(cfg *Config[H]) {
 		cfg.ProcessPreBlock = f
 	}

--- a/context.go
+++ b/context.go
@@ -370,16 +370,11 @@ func (c *Context[H]) MakeHeader() Block[H] {
 		if !c.RequestSentOrReceived() {
 			return nil
 		}
-		// For anti-MEV dBFT extension it's important to have at least M PreCommits received
-		// because PrepareRequest is not enough to construct proper block.
+		// For anti-MEV dBFT extension it's important to have PreBlock processed and
+		// all envelopes decrypted, because a single PrepareRequest is not enough to
+		// construct proper Block.
 		if c.isAntiMEVExtensionEnabled() {
-			var count int
-			for _, preCommit := range c.PreCommitPayloads {
-				if preCommit != nil && preCommit.ViewNumber() == c.ViewNumber {
-					count++
-				}
-			}
-			if count < c.M() {
+			if !c.preBlockProcessed {
 				return nil
 			}
 		}

--- a/context.go
+++ b/context.go
@@ -344,9 +344,6 @@ func (c *Context[H]) CreatePreBlock() PreBlock[H] {
 		if c.preBlock = c.MakePreHeader(); c.preBlock == nil {
 			return nil
 		}
-		if !c.hasAllTransactions() {
-			return nil
-		}
 
 		txx := make([]Transaction[H], len(c.TransactionHashes))
 

--- a/context.go
+++ b/context.go
@@ -344,6 +344,9 @@ func (c *Context[H]) CreatePreBlock() PreBlock[H] {
 		if c.preBlock = c.MakePreHeader(); c.preBlock == nil {
 			return nil
 		}
+		if !c.hasAllTransactions() {
+			return nil
+		}
 
 		txx := make([]Transaction[H], len(c.TransactionHashes))
 

--- a/dbft.go
+++ b/dbft.go
@@ -544,6 +544,9 @@ func (d *DBFT[H]) onPreCommit(msg ConsensusPayload[H]) {
 		d.Logger.Info("received PreCommit", zap.Uint("validator", uint(msg.ValidatorIndex())))
 		d.extendTimer(4)
 
+		if !d.hasAllTransactions() {
+			return
+		}
 		preBlock := d.CreatePreBlock()
 		if preBlock != nil {
 			pub := d.Validators[msg.ValidatorIndex()]

--- a/dbft_test.go
+++ b/dbft_test.go
@@ -1177,7 +1177,10 @@ func (s *testState) getAMEVOptions() []func(*dbft.Config[crypto.Uint256]) {
 		dbft.WithNewCommit[crypto.Uint256](consensus.NewAMEVCommit),
 		dbft.WithNewPreBlockFromContext[crypto.Uint256](newPreBlockFromContext),
 		dbft.WithNewBlockFromContext[crypto.Uint256](newAMEVBlockFromContext),
-		dbft.WithProcessPreBlock(func(b dbft.PreBlock[crypto.Uint256]) { s.preBlocks = append(s.preBlocks, b) }),
+		dbft.WithProcessPreBlock(func(b dbft.PreBlock[crypto.Uint256]) error {
+			s.preBlocks = append(s.preBlocks, b)
+			return nil
+		}),
 	)
 
 	return opts

--- a/pre_block.go
+++ b/pre_block.go
@@ -12,7 +12,8 @@ type PreBlock[H Hash] interface {
 	SetData(key PrivateKey) error
 	// Verify checks if data related to PreCommit phase is correct. This method is
 	// refined on PreBlock rather than on PreCommit message since PreBlock itself is
-	// required for PreCommit's data verification.
+	// required for PreCommit's data verification. It's guaranteed that all
+	// proposed transactions are collected by the moment of call to Verify.
 	Verify(key PublicKey, data []byte) error
 
 	// Transactions returns PreBlock's transaction list. This list may be different


### PR DESCRIPTION
The necessity of this extension is described in https://github.com/bane-labs/go-ethereum/pull/301#discussion_r1726514210. We need at least `M` _correct_ PreCommits to decrypt Envelopes content, but decryption may be checked only by using the group of PreCommits. Thus, we can't say whether a single PreCommit can/can't decrypt Envelopes content.

@roman-khimov, please, review it carefully, I checked what I could and there seems to be no tricks possible to skip verification, but maybe you'll fined something. May be it'll be easier to review if you take a look at https://github.com/bane-labs/go-ethereum/pull/287/commits/f4e830c751ae6a4ee94adb6db42096133abfa235.