### PR TITLE
context: enable anti-MEV extension starting from specified height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Improvements:
 Bugs fixed:
  * context-bound PreBlock and PreHeader are not reset properly (#127)   
  * PreHeader is constructed instead of PreBlock to create PreCommit message (#128)
+ * enable anti-MEV extension with respect to the current block index (#132)
 
 ## [0.3.0] (01 August 2024)
 

--- a/context.go
+++ b/context.go
@@ -360,7 +360,7 @@ func (c *Context[H]) CreatePreBlock() PreBlock[H] {
 // isAntiMEVExtensionEnabled returns whether Anti-MEV dBFT extension is enabled
 // at the currently processing block height.
 func (c *Context[H]) isAntiMEVExtensionEnabled() bool {
-	return c.Config.AntiMEVExtensionEnablingHeight >= 0 && uint32(c.Config.AntiMEVExtensionEnablingHeight) < c.BlockIndex
+	return c.Config.AntiMEVExtensionEnablingHeight >= 0 && uint32(c.Config.AntiMEVExtensionEnablingHeight) <= c.BlockIndex
 }
 
 // MakeHeader returns half-filled block for the current epoch.


### PR DESCRIPTION
Processing block should be taken into account while checking anti-MEV extension enabling height.