### PR TITLE
dbft: prohibit WatchOnly to send RecoveryMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Bugs fixed:
  * PreHeader is constructed instead of PreBlock to create PreCommit message (#128)
  * enable anti-MEV extension with respect to the current block index (#132)
  * (*Context).PreBlock() method returns PreHeader instead of PreBlock (#133)
+ * WatchOnly node may send RecoveryMessage on RecoveryRequest (#135)
 
 ## [0.3.0] (01 August 2024)
 

--- a/dbft.go
+++ b/dbft.go
@@ -610,6 +610,11 @@ func (d *DBFT[H]) onCommit(msg ConsensusPayload[H]) {
 }
 
 func (d *DBFT[H]) onRecoveryRequest(msg ConsensusPayload[H]) {
+	// Only validators are allowed to send consensus messages.
+	if d.Context.WatchOnly() {
+		return
+	}
+
 	if !d.CommitSent() && (!d.isAntiMEVExtensionEnabled() || !d.PreCommitSent()) {
 		// Ignore the message if our index is not in F+1 range of the
 		// next (%N) ones from the sender. This limits recovery


### PR DESCRIPTION
Fix a bug introduced by ffa8c1fc3299a2f710225a0aa14407c26641694f.