### PR TITLE
identity: simplify PrivateKey interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Behaviour changes:
  * (*DBFT).Header() and (*DBFT).PreHeader() are moved to (*Context) receiver (#133)
  * support error handling for ProcessBlock callback if anti-MEV extension is enabled
    (#134)
+ * remove Sign method from PrivateKey interface (#137)
 
 Improvements:
  * minimum required Go version is 1.22 (#122, #126)

--- a/identity.go
+++ b/identity.go
@@ -8,11 +8,12 @@ type (
 	// PublicKey is a generic public key interface used by dbft.
 	PublicKey any
 
-	// PrivateKey is a generic private key interface used by dbft.
-	PrivateKey interface {
-		// Sign returns msg's signature and error on failure.
-		Sign(msg []byte) (sig []byte, err error)
-	}
+	// PrivateKey is a generic private key interface used by dbft. PrivateKey is used
+	// only by [PreBlock] and [Block] signing callbacks ([PreBlock.SetData] and
+	// [Block.Sign]) to grant access to the private key abstraction to Block and
+	// PreBlock signing code. PrivateKey does not contain any methods, hence user
+	// supposed to perform type assertion before the PrivateKey usage.
+	PrivateKey any
 
 	// Hash is a generic hash interface used by dbft for payloads, blocks and
 	// transactions identification. It is recommended to implement this interface

--- a/internal/consensus/amev_block.go
+++ b/internal/consensus/amev_block.go
@@ -19,6 +19,8 @@ type amevBlock struct {
 	hash         *crypto.Uint256
 }
 
+var _ dbft.Block[crypto.Uint256] = new(amevBlock)
+
 // NewAMEVBlock returns new block based on PreBlock and additional Commit-level data
 // collected from M consensus nodes.
 func NewAMEVBlock(pre dbft.PreBlock[crypto.Uint256], cnData [][]byte, m int) dbft.Block[crypto.Uint256] {
@@ -95,7 +97,7 @@ func (b *amevBlock) GetHashData() []byte {
 func (b *amevBlock) Sign(key dbft.PrivateKey) error {
 	data := b.GetHashData()
 
-	sign, err := key.Sign(data)
+	sign, err := key.(*crypto.ECDSAPriv).Sign(data)
 	if err != nil {
 		return err
 	}

--- a/internal/consensus/block.go
+++ b/internal/consensus/block.go
@@ -29,7 +29,16 @@ type (
 		signature    []byte
 		hash         *crypto.Uint256
 	}
+
+	// signable is an interface used within consensus package to abstract private key
+	// functionality. This interface is used instead of direct structure usage to be
+	// able to mock private key implementation in unit tests.
+	signable interface {
+		Sign([]byte) ([]byte, error)
+	}
 )
+
+var _ dbft.Block[crypto.Uint256] = new(neoBlock)
 
 // PrevHash implements Block interface.
 func (b *neoBlock) PrevHash() crypto.Uint256 {
@@ -101,7 +110,7 @@ func (b *neoBlock) GetHashData() []byte {
 func (b *neoBlock) Sign(key dbft.PrivateKey) error {
 	data := b.GetHashData()
 
-	sign, err := key.Sign(data)
+	sign, err := key.(signable).Sign(data)
 	if err != nil {
 		return err
 	}

--- a/internal/consensus/block_test.go
+++ b/internal/consensus/block_test.go
@@ -64,6 +64,8 @@ func TestNeoBlock_Setters(t *testing.T) {
 
 type testKey struct{}
 
+var _ signable = testKey{}
+
 func (t testKey) MarshalBinary() ([]byte, error) { return []byte{}, nil }
 func (t testKey) UnmarshalBinary([]byte) error   { return nil }
 func (t testKey) Sign([]byte) ([]byte, error) {

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -15,7 +15,7 @@ func TestVerifySignature(t *testing.T) {
 	_, err := rand.Reader.Read(data)
 	require.NoError(t, err)
 
-	sign, err := priv.Sign(data)
+	sign, err := priv.(*ECDSAPriv).Sign(data)
 	require.NoError(t, err)
 	require.Equal(t, 64, len(sign))
 


### PR DESCRIPTION
PrivateKey.Sign() is not used by dBFT in any way. Block signing process is managed by Block.Sign() and PreBlock.SetData() methods, whereas consensus payload signing is out of dbft scope.