### PR TITLE
check: prohibit WatchOnly to send commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Behaviour changes:
 Improvements:
 
 Bugs fixed:
+ * inappropriate log on attempt to construct Commit for anti-MEV enabled WatchOnly
+   (#139)
 
 ## [0.3.1] (29 November 2024)
 


### PR DESCRIPTION
Problem:

Inappropriate message in the WatchOnly node logs with NeoXAMEV extension enabled:
```
2024-12-05T15:15:54.366+0300	INFO	dbft@v0.3.1/dbft.go:545	received PreCommit	{"validator": 5}
2024-12-05T15:15:54.366+0300	DEBUG	dbft@v0.3.1/check.go:90	can't send commit since self preCommit not yet sent
```

Based on these logs it may seem that WatchOnly is trying (or will try) to send Commit. It must never happen, hence I dived into the library code and discovered the condition that was added mostly for safety and that was planned to be removed in future:
https://github.com/nspcc-dev/dbft/blob/7c005d93e4b47106b679e3cc55d182f8167e0e56/check.go#L82-L84

Ref. https://github.com/nspcc-dev/dbft/pull/118#discussion_r1681631842.

So the problem is in the invalid documentaiton and in improper log message.

It should be noted that for non-WatchOnly CNs we also need to keep and check PreCommitSent requirement because node's Commit must be confirmed by previousely sent PreCommit.

Solution:

Strictly speaking, this commit almost doesn't change the dBFT behaviour because WatchOnly node is not allowed to send Commit thanks to the condition outlined above. But we'd better adjust the comment and don't confuse the library users with inappropriate message.