### PR TITLE
crypto/simulation: drop dead code and dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.22
 
 require (
 	github.com/stretchr/testify v1.9.0
-	github.com/twmb/murmur3 v1.1.8
 	go.uber.org/zap v1.27.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
-github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/internal/crypto/ecdsa.go
+++ b/internal/crypto/ecdsa.go
@@ -67,21 +67,9 @@ func (e *ECDSAPub) Equals(other dbft.PublicKey) bool {
 	return e.Equal(other.(*ECDSAPub).PublicKey)
 }
 
-// MarshalBinary implements encoding.BinaryMarshaler interface.
-func (e ECDSAPub) MarshalBinary() ([]byte, error) {
-	return elliptic.MarshalCompressed(e.PublicKey.Curve, e.PublicKey.X, e.PublicKey.Y), nil
-}
-
-// UnmarshalBinary implements encoding.BinaryUnmarshaler interface.
-func (e *ECDSAPub) UnmarshalBinary(data []byte) error {
-	e.PublicKey = new(ecdsa.PublicKey)
-	e.PublicKey.Curve = elliptic.P256()
-	e.PublicKey.X, e.PublicKey.Y = elliptic.UnmarshalCompressed(e.PublicKey.Curve, data)
-	if e.PublicKey.X == nil {
-		return errors.New("can't unmarshal ECDSA public key")
-	}
-
-	return nil
+// Compare does three-way comparison of ECDSAPub.
+func (e *ECDSAPub) Compare(p *ECDSAPub) int {
+	return e.X.Cmp(p.X)
 }
 
 // Verify verifies signature using P-256 curve.

--- a/internal/crypto/ecdsa_test.go
+++ b/internal/crypto/ecdsa_test.go
@@ -1,27 +1,11 @@
 package crypto
 
 import (
-	"crypto/rand"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestECDSA_MarshalUnmarshal(t *testing.T) {
-	priv, pub := generateECDSA(rand.Reader)
-	require.NotNil(t, priv)
-	require.NotNil(t, pub)
-
-	data, err := pub.(*ECDSAPub).MarshalBinary()
-	require.NoError(t, err)
-
-	pub1 := new(ECDSAPub)
-	require.NoError(t, pub1.UnmarshalBinary(data))
-	require.Equal(t, pub, pub1)
-
-	require.Error(t, pub1.UnmarshalBinary([]byte{0, 1, 2, 3}))
-}
 
 // Do not generate keys with not enough entropy.
 func TestECDSA_Generate(t *testing.T) {

--- a/internal/simulation/main.go
+++ b/internal/simulation/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/nspcc-dev/dbft"
 	"github.com/nspcc-dev/dbft/internal/consensus"
 	"github.com/nspcc-dev/dbft/internal/crypto"
-	"github.com/twmb/murmur3"
 	"go.uber.org/zap"
 )
 
@@ -153,9 +152,9 @@ func updatePublicKeys(nodes []*simNode, n int) {
 
 func sortValidators(pubs []dbft.PublicKey) {
 	slices.SortFunc(pubs, func(a, b dbft.PublicKey) int {
-		p1, _ := a.(*crypto.ECDSAPub).MarshalBinary()
-		p2, _ := b.(*crypto.ECDSAPub).MarshalBinary()
-		return int(murmur3.Sum64(p2)) - int(murmur3.Sum64(p1))
+		x := a.(*crypto.ECDSAPub)
+		y := b.(*crypto.ECDSAPub)
+		return x.Compare(y)
 	})
 }
 


### PR DESCRIPTION
We don't need murmur3 to sort validators and we don't need serialization code since a129fd72f1773c7f7f05b7b5bfa60703a645e676.