### PR TITLE
workflows: update tj-actions/changed-files to v46

### DIFF
--- a/.github/workflows/changelog_update.yml
+++ b/.github/workflows/changelog_update.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get changed CHANGELOG
         id: changelog-diff
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v46
         with:
           files: CHANGELOG.md
 


### PR DESCRIPTION
It was recently compromised and even though changes to tags were reverted it's still worth upgrading (GH also warns about <=45.0.7).

See https://github.com/tj-actions/changed-files/issues/2463