### PR TITLE
*: adapt state-dependent block producing time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This document outlines major changes between releases.
 New features:
 
 Behaviour changes:
+ * `SecondsPerBlock` config parameter is replaced with `TimePerBlock` function (#147)
 
 Improvements:
 

--- a/check.go
+++ b/check.go
@@ -39,11 +39,11 @@ func (d *DBFT[H]) checkPrepare() {
 	if hasRequest && count >= d.M() {
 		if d.isAntiMEVExtensionEnabled() {
 			d.sendPreCommit()
-			d.changeTimer(d.SecondsPerBlock)
+			d.changeTimer(d.timePerBlock)
 			d.checkPreCommit()
 		} else {
 			d.sendCommit()
-			d.changeTimer(d.SecondsPerBlock)
+			d.changeTimer(d.timePerBlock)
 			d.checkCommit()
 		}
 	}
@@ -94,7 +94,7 @@ func (d *DBFT[H]) checkPreCommit() {
 	if d.PreCommitSent() {
 		d.verifyCommitPayloadsAgainstHeader()
 		d.sendCommit()
-		d.changeTimer(d.SecondsPerBlock)
+		d.changeTimer(d.timePerBlock)
 		d.checkCommit()
 	} else {
 		if !d.Context.WatchOnly() {

--- a/config.go
+++ b/config.go
@@ -13,9 +13,9 @@ type Config[H Hash] struct {
 	Logger *zap.Logger
 	// Timer
 	Timer Timer
-	// SecondsPerBlock is the number of seconds that
-	// need to pass before another block will be accepted.
-	SecondsPerBlock time.Duration
+	// TimePerBlock is the time that need to pass before another block will
+	// be accepted. This value may be updated every block.
+	TimePerBlock func() time.Duration
 	// TimestampIncrement increment is the amount of units to add to timestamp
 	// if current time is less than that of previous context.
 	// By default use millisecond precision.
@@ -103,7 +103,7 @@ func defaultConfig[H Hash]() *Config[H] {
 	// fields which are set to nil must be provided from client
 	return &Config[H]{
 		Logger:             zap.NewNop(),
-		SecondsPerBlock:    defaultSecondsPerBlock,
+		TimePerBlock:       func() time.Duration { return defaultSecondsPerBlock },
 		TimestampIncrement: defaultTimestampIncrement,
 		GetKeyPair:         nil,
 		RequestTx:          func(...H) {},
@@ -196,10 +196,10 @@ func WithTimer[H Hash](t Timer) func(config *Config[H]) {
 	}
 }
 
-// WithSecondsPerBlock sets SecondsPerBlock.
-func WithSecondsPerBlock[H Hash](d time.Duration) func(config *Config[H]) {
+// WithTimePerBlock sets TimePerBlock.
+func WithTimePerBlock[H Hash](f func() time.Duration) func(config *Config[H]) {
 	return func(cfg *Config[H]) {
-		cfg.SecondsPerBlock = d
+		cfg.TimePerBlock = f
 	}
 }
 

--- a/context.go
+++ b/context.go
@@ -91,6 +91,7 @@ type Context[H Hash] struct {
 	lastBlockTime      time.Time // Wall clock time of when we started (as in PrepareRequest) creating the last block (used for timer adjustments).
 	lastBlockIndex     uint32
 	lastBlockView      byte
+	timePerBlock       time.Duration // amount of time that need to pass before the pending block will be accepted.
 
 	prepareSentTime time.Time
 	rttEstimates    rtt
@@ -246,6 +247,7 @@ func (c *Context[H]) reset(view byte, ts uint64) {
 		c.PrevHash = c.Config.CurrentBlockHash()
 		c.BlockIndex = c.Config.CurrentHeight() + 1
 		c.Validators = c.Config.GetValidators()
+		c.timePerBlock = c.Config.TimePerBlock()
 
 		n := len(c.Validators)
 		c.LastChangeViewPayloads = emptyReusableSlice(c.LastChangeViewPayloads, n)

--- a/dbft.go
+++ b/dbft.go
@@ -144,10 +144,10 @@ func (d *DBFT[H]) initializeConsensus(view byte, ts uint64) {
 		// In both cases we should wait full timeout value.
 		// Having non-zero view means we have to start immediately.
 		if view == 0 {
-			timeout = d.SecondsPerBlock
+			timeout = d.timePerBlock
 		}
 	} else {
-		timeout = d.SecondsPerBlock << (d.ViewNumber + 1)
+		timeout = d.timePerBlock << (d.ViewNumber + 1)
 	}
 	if d.lastBlockIndex+1 == d.BlockIndex {
 		var ts = d.Timer.Now()
@@ -210,7 +210,7 @@ func (d *DBFT[H]) OnTimeout(height uint32, view byte) {
 		if d.CommitSent() || d.PreCommitSent() {
 			d.Logger.Debug("send recovery to resend commit")
 			d.sendRecoveryMessage()
-			d.changeTimer(d.SecondsPerBlock << 1)
+			d.changeTimer(d.timePerBlock << 1)
 		} else {
 			d.sendChangeView(CVTimeout)
 		}
@@ -718,6 +718,6 @@ func (d *DBFT[H]) changeTimer(delay time.Duration) {
 
 func (d *DBFT[H]) extendTimer(count int) {
 	if !d.CommitSent() && (!d.isAntiMEVExtensionEnabled() || !d.PreCommitSent()) && !d.ViewChanging() {
-		d.Timer.Extend(time.Duration(count) * d.SecondsPerBlock / time.Duration(d.M()))
+		d.Timer.Extend(time.Duration(count) * d.timePerBlock / time.Duration(d.M()))
 	}
 }

--- a/dbft_test.go
+++ b/dbft_test.go
@@ -1137,7 +1137,9 @@ func (s *testState) getOptions() []func(*dbft.Config[crypto.Uint256]) {
 		dbft.WithTimer[crypto.Uint256](timer.New()),
 		dbft.WithLogger[crypto.Uint256](zap.NewNop()),
 		dbft.WithNewBlockFromContext[crypto.Uint256](newBlockFromContext),
-		dbft.WithSecondsPerBlock[crypto.Uint256](time.Second * 10),
+		dbft.WithTimePerBlock[crypto.Uint256](func() time.Duration {
+			return time.Second * 10
+		}),
 		dbft.WithRequestTx[crypto.Uint256](func(...crypto.Uint256) {}),
 		dbft.WithGetVerified[crypto.Uint256](func() []dbft.Transaction[crypto.Uint256] { return []dbft.Transaction[crypto.Uint256]{} }),
 

--- a/internal/consensus/consensus.go
+++ b/internal/consensus/consensus.go
@@ -21,7 +21,9 @@ func New(logger *zap.Logger, key dbft.PrivateKey, pub dbft.PublicKey,
 	return dbft.New[crypto.Uint256](
 		dbft.WithTimer[crypto.Uint256](timer.New()),
 		dbft.WithLogger[crypto.Uint256](logger),
-		dbft.WithSecondsPerBlock[crypto.Uint256](time.Second*5),
+		dbft.WithTimePerBlock[crypto.Uint256](func() time.Duration {
+			return time.Second * 5
+		}),
 		dbft.WithGetKeyPair[crypto.Uint256](func(pubs []dbft.PublicKey) (int, dbft.PrivateKey, dbft.PublicKey) {
 			for i := range pubs {
 				if pub.(*crypto.ECDSAPub).Equals(pubs[i]) {

--- a/send.go
+++ b/send.go
@@ -31,9 +31,9 @@ func (d *DBFT[H]) sendPrepareRequest() {
 
 	d.prepareSentTime = d.Timer.Now()
 
-	delay := d.SecondsPerBlock << (d.ViewNumber + 1)
+	delay := d.timePerBlock << (d.ViewNumber + 1)
 	if d.ViewNumber == 0 {
-		delay -= d.SecondsPerBlock
+		delay -= d.timePerBlock
 	}
 
 	d.Logger.Info("sending PrepareRequest", zap.Uint32("height", d.BlockIndex), zap.Uint("view", uint(d.ViewNumber)))
@@ -56,7 +56,7 @@ func (d *DBFT[H]) sendChangeView(reason ChangeViewReason) {
 	}
 
 	newView := d.ViewNumber + 1
-	d.changeTimer(d.SecondsPerBlock << (newView + 1))
+	d.changeTimer(d.timePerBlock << (newView + 1))
 
 	nc := d.CountCommitted()
 	nf := d.CountFailed()


### PR DESCRIPTION
Ref. https://github.com/nspcc-dev/neo-go/issues/3745.

Let's firstly finalize https://github.com/nspcc-dev/neo-go/pull/3835 before the merge, because we might want to add `height` parameter to `WithSecondsPerBlock` setting (to me it's not needed, but still may be considered).