### PR TITLE
Revert timer related changes

### DIFF
--- a/timer/timer.go
+++ b/timer/timer.go
@@ -61,7 +61,15 @@ func (t *Timer) Reset(height uint32, view byte, d time.Duration) {
 		t.tt = time.NewTimer(t.d)
 	} else {
 		t.tt = nil
+		drain(t.ch)
 		t.ch <- t.s
+	}
+}
+
+func drain(ch <-chan time.Time) {
+	select {
+	case <-ch:
+	default:
 	}
 }
 


### PR DESCRIPTION
This reverts commit 8dfda6b83b60dc59ccd6cbdf134831d495a5abf9 and f7a23ed.

This change is needed because external users of the library should be able to stop the dBFT timer:
https://github.com/nspcc-dev/neo-go/blob/3e54c46281237124da7fd89a90501a9d58a3aa60/pkg/consensus/consensus.go#L342