### PR TITLE
*: support dynamic block time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This document outlines major changes between releases.
 ## [Unreleased]
 
 New features:
+ * `MaxTimePerBlock` and `SubscribeForTxs` configuration parameters are added
+   to support dynamic block time extension (#150)
 
 Behaviour changes:
  * `SecondsPerBlock` config parameter is replaced with `TimePerBlock` function (#147)

--- a/config.go
+++ b/config.go
@@ -132,44 +132,63 @@ func defaultConfig[H Hash]() *Config[H] {
 func checkConfig[H Hash](cfg *Config[H]) error {
 	if cfg.GetKeyPair == nil {
 		return errors.New("private key is nil")
-	} else if cfg.Timer == nil {
+	}
+	if cfg.Timer == nil {
 		return errors.New("Timer is nil")
-	} else if cfg.CurrentHeight == nil {
+	}
+	if cfg.CurrentHeight == nil {
 		return errors.New("CurrentHeight is nil")
-	} else if cfg.CurrentBlockHash == nil {
+	}
+	if cfg.CurrentBlockHash == nil {
 		return errors.New("CurrentBlockHash is nil")
-	} else if cfg.GetValidators == nil {
+	}
+	if cfg.GetValidators == nil {
 		return errors.New("GetValidators is nil")
-	} else if cfg.NewBlockFromContext == nil {
+	}
+	if cfg.NewBlockFromContext == nil {
 		return errors.New("NewBlockFromContext is nil")
-	} else if cfg.NewConsensusPayload == nil {
+	}
+	if cfg.NewConsensusPayload == nil {
 		return errors.New("NewConsensusPayload is nil")
-	} else if cfg.NewPrepareRequest == nil {
+	}
+	if cfg.NewPrepareRequest == nil {
 		return errors.New("NewPrepareRequest is nil")
-	} else if cfg.NewPrepareResponse == nil {
+	}
+	if cfg.NewPrepareResponse == nil {
 		return errors.New("NewPrepareResponse is nil")
-	} else if cfg.NewChangeView == nil {
+	}
+	if cfg.NewChangeView == nil {
 		return errors.New("NewChangeView is nil")
-	} else if cfg.NewCommit == nil {
+	}
+	if cfg.NewCommit == nil {
 		return errors.New("NewCommit is nil")
-	} else if cfg.NewRecoveryRequest == nil {
+	}
+	if cfg.NewRecoveryRequest == nil {
 		return errors.New("NewRecoveryRequest is nil")
-	} else if cfg.NewRecoveryMessage == nil {
+	}
+	if cfg.NewRecoveryMessage == nil {
 		return errors.New("NewRecoveryMessage is nil")
-	} else if cfg.AntiMEVExtensionEnablingHeight >= 0 {
+	}
+	if cfg.AntiMEVExtensionEnablingHeight >= 0 {
 		if cfg.NewPreBlockFromContext == nil {
 			return errors.New("NewPreBlockFromContext is nil")
-		} else if cfg.ProcessPreBlock == nil {
+		}
+		if cfg.ProcessPreBlock == nil {
 			return errors.New("ProcessPreBlock is nil")
-		} else if cfg.NewPreCommit == nil {
+		}
+		if cfg.NewPreCommit == nil {
 			return errors.New("NewPreCommit is nil")
 		}
-	} else if cfg.NewPreBlockFromContext != nil {
-		return errors.New("NewPreBlockFromContext is set, but AntiMEVExtensionEnablingHeight is not specified")
-	} else if cfg.ProcessPreBlock != nil {
-		return errors.New("ProcessPreBlock is set, but AntiMEVExtensionEnablingHeight is not specified")
-	} else if cfg.NewPreCommit != nil {
-		return errors.New("NewPreCommit is set, but AntiMEVExtensionEnablingHeight is not specified")
+	} else {
+		if cfg.NewPreBlockFromContext != nil {
+			return errors.New("NewPreBlockFromContext is set, but AntiMEVExtensionEnablingHeight is not specified")
+		}
+		if cfg.ProcessPreBlock != nil {
+			return errors.New("ProcessPreBlock is set, but AntiMEVExtensionEnablingHeight is not specified")
+		}
+		if cfg.NewPreCommit != nil {
+			return errors.New("NewPreCommit is set, but AntiMEVExtensionEnablingHeight is not specified")
+		}
 	}
 
 	return nil

--- a/dbft_test.go
+++ b/dbft_test.go
@@ -577,7 +577,15 @@ func TestDBFT_Invalid(t *testing.T) {
 
 	opts = append(opts, dbft.WithNewRecoveryMessage[crypto.Uint256](func() dbft.RecoveryMessage[crypto.Uint256] {
 		return nil
+	}), dbft.WithMaxTimePerBlock[crypto.Uint256](func() time.Duration {
+		return 0
 	}))
+	t.Run("MaxTimePerBlock without SubscribeForTxs", func(t *testing.T) {
+		_, err := dbft.New(opts...)
+		require.ErrorContains(t, err, "MaxTimePerBlock and SubscribeForTxs should be specified/not specified at the same time")
+	})
+
+	opts = append(opts, dbft.WithSubscribeForTxs[crypto.Uint256](func() {}))
 	t.Run("with all defaults", func(t *testing.T) {
 		d, err := dbft.New(opts...)
 		require.NoError(t, err)


### PR DESCRIPTION
The most part of transaction awaiting logic is managed by NeoGo, so dBFT is not changed a lot.

TODO:

- [x] Refactor transaction awaiting to match https://github.com/nspcc-dev/dbft/issues/149#issue-3169103954.
- [x] Test edge cases. 

Close #149.

An example of block with a single transaction accepted prior to MaxtimePerBlock (consensus with 1s-20 block time):
```
2025-07-11T15:38:34.748Z	INFO	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/check.go:130	approving block	{"height": 2, "hash": "f0d777dbf57bb9d98c68f7eb9707ee032cbd325aa92209579452970e7a42e918", "tx_count": 0, "merkle": "0000000000000000000000000000000000000000000000000000000000000000", "prev": "79ef87a82d2850bf938a34a2e36ef7116822bd2d93717a4dd98cf2049087086f"}
2025-07-11T15:38:34.748Z	DEBUG	consensus/consensus.go:379	received message	{"from": 0, "type": "Commit"}
2025-07-11T15:38:34.748Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:259	received message	{"type": "Commit", "from": 0, "height": 2, "view": 0, "my_height": 2, "my_view": 0}
2025-07-11T15:38:34.749Z	DEBUG	consensus/consensus.go:421	new block in the chain	{"dbft index": 2, "chain index": 2}
2025-07-11T15:38:34.749Z	INFO	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:112	initializing dbft	{"height": 3, "view": 0, "index": 2, "role": "Backup"}
2025-07-11T15:38:34.749Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:739	reset timer	{"h": 3, "v": 0, "delay": "1.996061079s"}
2025-07-11T15:38:35.213Z	INFO	persisted to disk	{"blocks": 1, "keys": 19, "headerHeight": 2, "blockHeight": 2, "took": "2.405955ms"}
2025-07-11T15:38:36.745Z	DEBUG	consensus/consensus.go:351	timer fired	{"height": 3, "view": 0}
2025-07-11T15:38:36.745Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:216	timeout	{"height": 3, "view": 0}
2025-07-11T15:38:36.745Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:739	reset timer	{"h": 3, "v": 0, "delay": "38s"}
2025-07-11T15:38:39.918Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:216	timeout	{"height": 3, "view": 0}
2025-07-11T15:38:39.918Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:739	reset timer	{"h": 3, "v": 0, "delay": "2s"}
2025-07-11T15:38:39.919Z	DEBUG	consensus/consensus.go:379	received message	{"from": 3, "type": "PrepareRequest"}
2025-07-11T15:38:39.919Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:259	received message	{"type": "PrepareRequest", "from": 3, "height": 3, "view": 0, "my_height": 3, "my_view": 0}
2025-07-11T15:38:39.919Z	INFO	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:353	received PrepareRequest	{"validator": 3, "tx": 1}
2025-07-11T15:38:39.919Z	INFO	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/send.go:117	sending PrepareResponse	{"height": 3, "view": 0}
2025-07-11T15:38:39.919Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/send.go:10	broadcasting message	{"type": "PrepareResponse", "height": 3, "view": 0}
2025-07-11T15:38:39.919Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/check.go:35	check preparations	{"hasReq": true, "count": 2, "M": 3}
2025-07-11T15:38:39.919Z	DEBUG	consensus/consensus.go:379	received message	{"from": 1, "type": "PrepareResponse"}
2025-07-11T15:38:39.919Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:259	received message	{"type": "PrepareResponse", "from": 1, "height": 3, "view": 0, "my_height": 3, "my_view": 0}
2025-07-11T15:38:39.919Z	INFO	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:492	received PrepareResponse	{"validator": 1}
2025-07-11T15:38:39.919Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/check.go:35	check preparations	{"hasReq": true, "count": 3, "M": 3}
2025-07-11T15:38:39.919Z	INFO	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/send.go:182	sending Commit	{"height": 3, "view": 0}
2025-07-11T15:38:39.919Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/send.go:10	broadcasting message	{"type": "Commit", "height": 3, "view": 0}
2025-07-11T15:38:39.919Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:739	reset timer	{"h": 3, "v": 0, "delay": "1s"}
2025-07-11T15:38:39.919Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/check.go:123	not enough to commit	{"count": 1}
2025-07-11T15:38:39.919Z	DEBUG	consensus/consensus.go:379	received message	{"from": 0, "type": "PrepareResponse"}
2025-07-11T15:38:39.919Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:259	received message	{"type": "PrepareResponse", "from": 0, "height": 3, "view": 0, "my_height": 3, "my_view": 0}
2025-07-11T15:38:39.920Z	INFO	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:492	received PrepareResponse	{"validator": 0}
2025-07-11T15:38:39.920Z	DEBUG	consensus/consensus.go:379	received message	{"from": 3, "type": "Commit"}
2025-07-11T15:38:39.920Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:259	received message	{"type": "Commit", "from": 3, "height": 3, "view": 0, "my_height": 3, "my_view": 0}
2025-07-11T15:38:39.920Z	INFO	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:627	received Commit	{"validator": 3}
2025-07-11T15:38:39.920Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/check.go:123	not enough to commit	{"count": 2}
2025-07-11T15:38:39.920Z	DEBUG	consensus/consensus.go:379	received message	{"from": 1, "type": "Commit"}
2025-07-11T15:38:39.920Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:259	received message	{"type": "Commit", "from": 1, "height": 3, "view": 0, "my_height": 3, "my_view": 0}
2025-07-11T15:38:39.920Z	INFO	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:627	received Commit	{"validator": 1}
2025-07-11T15:38:39.920Z	INFO	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/check.go:130	approving block	{"height": 3, "hash": "bbc60b6ed5f19d3b306844806ea763b2224f40542e9bd49d440ffb3d157c59c6", "tx_count": 1, "merkle": "07b5c809427a121be624ce93d508c2c8ac7f6760c28227fa065e621ee7cf3dbc", "prev": "f0d777dbf57bb9d98c68f7eb9707ee032cbd325aa92209579452970e7a42e918"}
2025-07-11T15:38:39.920Z	DEBUG	consensus/consensus.go:379	received message	{"from": 0, "type": "Commit"}
2025-07-11T15:38:39.920Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:259	received message	{"type": "Commit", "from": 0, "height": 3, "view": 0, "my_height": 3, "my_view": 0}
2025-07-11T15:38:39.921Z	DEBUG	consensus/consensus.go:421	new block in the chain	{"dbft index": 3, "chain index": 3}
2025-07-11T15:38:39.921Z	INFO	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:112	initializing dbft	{"height": 4, "view": 0, "index": 2, "role": "Backup"}
2025-07-11T15:38:39.921Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:739	reset timer	{"h": 4, "v": 0, "delay": "1.997789065s"}
2025-07-11T15:38:40.217Z	INFO	persisted to disk	{"blocks": 1, "keys": 34, "headerHeight": 3, "blockHeight": 3, "took": "2.197348ms"}
2025-07-11T15:38:41.919Z	DEBUG	consensus/consensus.go:351	timer fired	{"height": 4, "view": 0}
2025-07-11T15:38:41.919Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:216	timeout	{"height": 4, "view": 0}
2025-07-11T15:38:41.919Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:739	reset timer	{"h": 4, "v": 0, "delay": "38s"}
2025-07-11T15:38:59.923Z	DEBUG	consensus/consensus.go:379	received message	{"from": 0, "type": "PrepareRequest"}
2025-07-11T15:38:59.923Z	DEBUG	dbft@v0.3.3-0.20250711145350-dacd9067b3f7/dbft.go:259	received message	{"type": "PrepareRequest", "from": 0, "height": 4, "view": 0, "my_height": 4, "my_view": 0}

```